### PR TITLE
Migration Test from Hadoop Catalog into LakeFS

### DIFF
--- a/src/test/java/io/lakefs/iceberg/TestCatalogMigration.java
+++ b/src/test/java/io/lakefs/iceberg/TestCatalogMigration.java
@@ -10,90 +10,109 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
+import java.util.HashMap;
 import java.util.List;
 
 public class TestCatalogMigration {
-    public static SparkConf newSparkSharedConfig(String repo)  {
+    public static SparkConf newSparkSharedConfig(HashMap<String,String> lakeFSConf,  HashMap<String, String> srcConf)  {
         // per bucket config https://docs.cloudera.com/HDPDocuments/HDP3/HDP-3.1.4/bk_cloud-data-access/content/s3-per-bucket-configs.html
         SparkConf conf = new SparkConf();
-        // set hive config
-        conf.set("spark.sql.catalog.hadoop_prod", "org.apache.iceberg.spark.SparkCatalog");
-        conf.set("spark.sql.catalog.hadoop_prod.type", "hadoop");
-        conf.set("spark.sql.catalog.hadoop_prod.warehouse", "s3a://treeverse-ort-simulation-bucket/isan/iceberg-tests/");
-        conf.set("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions");
-        conf.set("spark.hadoop.fs.s3a.bucket.treeverse-ort-simulation-bucket.access.key", "AWS_ACCESS_KEY_SOURCE_HIVE");
-        conf.set("spark.hadoop.fs.s3a.bucket.treeverse-ort-simulation-bucket.secret.key", "AWS_SECRET_KEY_SOURCE_HIVE");
         conf.set("spark.hadoop.fs.s3a.path.style.access", "true");
-        // set lakeFS config
-        conf.set("spark.sql.catalog.lakefs", "org.apache.iceberg.spark.SparkCatalog");
-        conf.set("spark.sql.catalog.lakefs.catalog-impl", "io.lakefs.iceberg.LakeFSCatalog");
-        conf.set("spark.sql.catalog.lakefs.warehouse", String.format("lakefs://%s", repo));
-        conf.set("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions");
-        conf.set(String.format("spark.hadoop.fs.s3a.bucket.%s.access.key", repo), "<LAKEFS_ACCESS_KEY>");
-        conf.set(String.format("spark.hadoop.fs.s3a.bucket.%s.secret.key", repo), "<LAKEFS_SECRET_KEY>");
-        conf.set(String.format("spark.hadoop.fs.s3a.bucket.%s.endpoint"  , repo), "<LAKEFS_ENDPOINT_URL>");
+        if (srcConf != null){
+            // set hive config
+            conf.set("spark.sql.catalog.hadoop_prod", "org.apache.iceberg.spark.SparkCatalog");
+            conf.set("spark.sql.catalog.hadoop_prod.type", "hadoop");
+            conf.set("spark.sql.catalog.hadoop_prod.warehouse", String.format("s3a://%s/%s", srcConf.get("bucket"), srcConf.get("base_path")));
+            conf.set("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions");
+            conf.set(String.format("spark.hadoop.fs.s3a.bucket.%s.access.key", srcConf.get("bucket")), srcConf.get("aws_access_key"));
+            conf.set(String.format("spark.hadoop.fs.s3a.bucket.%s.secret.key", srcConf.get("bucket")), srcConf.get("aws_secret_key"));
+        }
+        if (lakeFSConf != null) {
+            // set lakeFS config
+            conf.set("spark.sql.catalog.lakefs", "org.apache.iceberg.spark.SparkCatalog");
+            conf.set("spark.sql.catalog.lakefs.catalog-impl", "io.lakefs.iceberg.LakeFSCatalog");
+            conf.set("spark.sql.catalog.lakefs.warehouse", String.format("lakefs://%s", lakeFSConf.get("repo")));
+            conf.set("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions");
+            conf.set(String.format("spark.hadoop.fs.s3a.bucket.%s.access.key", lakeFSConf.get("repo")), lakeFSConf.get("access_key"));
+            conf.set(String.format("spark.hadoop.fs.s3a.bucket.%s.secret.key", lakeFSConf.get("repo")), lakeFSConf.get("secret_key"));
+            conf.set(String.format("spark.hadoop.fs.s3a.bucket.%s.endpoint"  , lakeFSConf.get("repo")), lakeFSConf.get("endpoint"));
+        }
         return conf;
     }
 
     @Test
-    public void testStandaloneIcebergSpark() throws NoSuchTableException {
-        // directory-based catalog in HDFS that can be configured using type=hadoop
-        SparkConf conf = new SparkConf();
-        conf.set("spark.sql.catalog.hadoop_prod", "org.apache.iceberg.spark.SparkCatalog");
-        conf.set("spark.sql.catalog.hadoop_prod.type", "hadoop");
-        conf.set("spark.sql.catalog.hadoop_prod.warehouse", "s3a://treeverse-ort-simulation-bucket/isan/iceberg-tests/");
-        conf.set("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions");
-        conf.set("spark.hadoop.fs.s3a.access.key", "AWS_ACCESS_KEY_SOURCE_HIVE");
-        conf.set("spark.hadoop.fs.s3a.secret.key", "AWS_SECRET_KEY_SOURCE_HIVE");
-        conf.set("spark.hadoop.fs.s3a.path.style.access", "true");
+    public void testMigrateHadoopToLakeFSCatalog() throws NoSuchTableException {
 
+        var catalog = "hadoop_prod";
+        var db = "db";
+        var table = "mytable";
+        var branch = "main";
+        var lakeFSCatalog = "lakefs";
+        var lakeFSRepo = "<LAKEFS_TABLE_NAME>";
+
+        // hadoop catalog on s3 iceberg config (source)
+        HashMap<String, String> hadoopConf = new HashMap<>();
+        hadoopConf.put("bucket", "treeverse-ort-simulation-bucket");
+        hadoopConf.put("base_path", "isan/iceberg-tests2/");
+        hadoopConf.put("aws_access_key","<AWS_ACCESS_KEY>");
+        hadoopConf.put("aws_secret_key","<AWS_SECRET_KEY>");
+
+        // lakefs catalog iceberg config (destination)
+        HashMap<String, String> lakeFSConf = new HashMap<>();
+        lakeFSConf.put("access_key", "<LAKEFS_ACCESS_KEY>");
+        lakeFSConf.put("secret_key", "<LAKEFS_SECRET_KEY>");
+        lakeFSConf.put("endpoint", "<LAKEFS_ENDPOINT>");
+        lakeFSConf.put("repo", lakeFSRepo);
+
+        // pre-lakeFS simulate hadoop catalog on s3 catalog iceberg table
+
+        // create spark session for hadoop on s3 catalog
+        var conf = TestCatalogMigration.newSparkSharedConfig( null, hadoopConf);
         SparkSession spark = SparkSession.builder().master("local").config(conf).getOrCreate();
 
-        String catalog = "hadoop_prod";
-        String db = "db";
-        String table = "mytable";
-        String branch = "main";
-        spark.sql(String.format("CREATE SCHEMA IF NOT EXISTS %s.%s_%s", catalog, branch, db));
-        spark.sql(String.format("CREATE TABLE IF NOT EXISTS  %s.%s_%s_%s (val int) OPTIONS ('format-version'=2)", catalog, branch, db, table));
+        // create table in hadoop catalog
+        spark.sql(String.format("CREATE SCHEMA IF NOT EXISTS %s.%s", catalog,db));
+        spark.sql(String.format("CREATE TABLE IF NOT EXISTS  %s.%s_%s (val int) OPTIONS ('format-version'=2)", catalog, db, table));
         StructType schema = new StructType(new StructField[]{
                 DataTypes.createStructField("val", DataTypes.IntegerType, false)
         });
+
+        // populate with data
         Row row = RowFactory.create(10);
         Dataset<Row> df = spark.createDataFrame(List.of(row), schema).toDF("val");
-        df.writeTo(String.format("%s.%s_%s_%s", catalog, branch, db, table)).append();
-        spark.sql(String.format("SELECT * FROM %s.%s_%s_%s", catalog, branch, db, table)).show();
-    }
-    @Test
-    public void testCopyTablesFromIcebergToLakeFS() throws NoSuchTableException {
-        // connect to hadoop iceberg (none lakeFS)
-        String catalog = "hadoop_prod";
-        String lakeFSCatalog = "lakefs";
-        String db = "db";
-        String table = "mytable";
-        String branch = "main";
-//        String lakeFSRepo = "iceberg-one";
-        String lakeFSRepo = "iceberg-two";
-        SparkConf conf = TestCatalogMigration.newSparkSharedConfig(lakeFSRepo);
-        SparkSession spark = SparkSession.builder().master("local").config(conf).getOrCreate();
-        // hive table
-        System.out.println("showing Hive source data");
-        String hiveFullTableName = String.format("%s.%s_%s_%s", catalog, branch, db, table);
-        //spark.sql(String.format("SELECT * FROM %s.%s_%s_%s", catalog, branch, db, table)).show();
+        df.writeTo(String.format("%s.%s_%s", catalog, db, table)).append();
 
-        System.out.println("showing lakeFS destination data");
+        // show created data
+        spark.sql(String.format("SELECT * FROM %s.%s_%s", catalog, db, table));
 
-        // lakeFS table
-        String lakeFSFullTableName=String.format("%s.%s.%s.%s", lakeFSCatalog, branch, db, table);
+        // stop the hadoop spark session
+        spark.stop();
 
-        // create schema
-        spark.sql(String.format("CREATE SCHEMA IF NOT EXISTS %s.%s.%s", lakeFSCatalog, branch, db));
+        // simulate migration into lakeFS catalog for an iceberg table
 
-        // clone table
-        spark.sql(String.format("CREATE TABLE IF NOT EXISTS %s USING iceberg AS SELECT * FROM %s", lakeFSFullTableName,hiveFullTableName));
+        var hiveFullTableName = String.format("%s.%s_%s", catalog, db, table);
+        var lakeFSFullTableName=String.format("%s.%s.%s.%s", lakeFSCatalog, branch, db, table);
+
+        // create spark session that is configured to both source (hadoop catalog) and lakeFS catalog.
+
+        SparkConf sharedConf = TestCatalogMigration.newSparkSharedConfig(lakeFSConf, hadoopConf);
+        SparkSession sharedSpark = SparkSession.builder().master("local").config(sharedConf).getOrCreate();
+
+        // create schema in lakeFS
+        sharedSpark.sql(String.format("CREATE SCHEMA IF NOT EXISTS %s.%s.%s", lakeFSCatalog, branch, db));
+
+        // migrate iceberg table into lakeFS
+        sharedSpark.sql(String.format("CREATE TABLE IF NOT EXISTS %s USING iceberg AS SELECT * FROM %s", lakeFSFullTableName,hiveFullTableName));
 
         // show cloned table in lakeFS
-        spark.sql(String.format("SELECT * FROM %s.%s.%s.%s", lakeFSCatalog, branch, db, table)).show();
+        var lakeFSDf = sharedSpark.sql(String.format("SELECT * FROM %s.%s.%s.%s", lakeFSCatalog, branch, db, table));
+        lakeFSDf.show();
+
+        // assert source and target tables are equal
+        var diff = lakeFSDf.except(sharedSpark.sql(String.format("SELECT * FROM %s", hiveFullTableName)));
+        assertEquals(true, diff.isEmpty());
     }
 
 }


### PR DESCRIPTION
- Added test `testMigrateHadoopToLakeFSCatalog` 
The goal is to check migration from non-lakeFS catalog.