### PR TITLE
handle external paths

### DIFF
--- a/src/main/java/io/lakefs/iceberg/LakeFSFileIO.java
+++ b/src/main/java/io/lakefs/iceberg/LakeFSFileIO.java
@@ -30,11 +30,14 @@ public class LakeFSFileIO implements FileIO {
         return wrapped.properties();
     }
 
-
     @Override
     public InputFile newInputFile(String path) {
         if (!path.startsWith("s3a://")) {
             path = String.format("s3a://%s/%s/%s", lakeFSRepo, lakeFSRef, path);
+        }
+        if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {
+            // not a path in the repository, treat as a regular path
+            return wrapped.newInputFile(path);
         }
         return HadoopInputFile.fromPath(new LakeFSPath(path), wrapped.conf());
     }
@@ -44,6 +47,10 @@ public class LakeFSFileIO implements FileIO {
         if (!path.startsWith("s3a://")) {
             path = String.format("s3a://%s/%s/%s", lakeFSRepo, lakeFSRef, path);
         }
+        if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {
+            // not a path in the repository, treat as a regular path
+            return wrapped.newInputFile(path, length);
+        }
         return HadoopInputFile.fromPath(new LakeFSPath(path), length, wrapped.conf());
     }
 
@@ -51,6 +58,10 @@ public class LakeFSFileIO implements FileIO {
     public OutputFile newOutputFile(String path) {
         if (!path.startsWith("s3a://")) {
             path = String.format("s3a://%s/%s/%s", lakeFSRepo, lakeFSRef, path);
+        }
+        if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {
+            // not a path in the repository, treat as a regular path
+            return wrapped.newOutputFile(path);
         }
         return HadoopOutputFile.fromPath(new LakeFSPath(path), wrapped.conf());
     }

--- a/src/main/java/io/lakefs/iceberg/LakeFSFileIO.java
+++ b/src/main/java/io/lakefs/iceberg/LakeFSFileIO.java
@@ -36,11 +36,9 @@ public class LakeFSFileIO implements FileIO {
             path = String.format("s3a://%s/%s/%s", lakeFSRepo, lakeFSRef, path);
         }
         if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {
-            System.out.println(String.format("path %s does not start with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
             // not a path in the repository, treat as a regular path
             return wrapped.newInputFile(path);
         }
-        System.out.println(String.format("path %s starts with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
         return HadoopInputFile.fromPath(new LakeFSPath(path), wrapped.conf());
     }
 
@@ -51,10 +49,8 @@ public class LakeFSFileIO implements FileIO {
         }
         if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {
             // not a path in the repository, treat as a regular path
-            System.out.println(String.format("path %s does not start with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
             return wrapped.newInputFile(path, length);
         }
-        System.out.println(String.format("path %s starts with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
         return HadoopInputFile.fromPath(new LakeFSPath(path), length, wrapped.conf());
     }
 
@@ -64,11 +60,9 @@ public class LakeFSFileIO implements FileIO {
             path = String.format("s3a://%s/%s/%s", lakeFSRepo, lakeFSRef, path);
         }
         if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {
-            System.out.println(String.format("path %s does not start with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
             // not a path in the repository, treat as a regular path
             return wrapped.newOutputFile(path);
         }
-        System.out.println(String.format("path %s starts with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
         return HadoopOutputFile.fromPath(new LakeFSPath(path), wrapped.conf());
     }
 

--- a/src/main/java/io/lakefs/iceberg/LakeFSFileIO.java
+++ b/src/main/java/io/lakefs/iceberg/LakeFSFileIO.java
@@ -36,9 +36,11 @@ public class LakeFSFileIO implements FileIO {
             path = String.format("s3a://%s/%s/%s", lakeFSRepo, lakeFSRef, path);
         }
         if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {
+            System.out.println(String.format("path %s does not start with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
             // not a path in the repository, treat as a regular path
             return wrapped.newInputFile(path);
         }
+        System.out.println(String.format("path %s starts with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
         return HadoopInputFile.fromPath(new LakeFSPath(path), wrapped.conf());
     }
 
@@ -49,8 +51,10 @@ public class LakeFSFileIO implements FileIO {
         }
         if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {
             // not a path in the repository, treat as a regular path
+            System.out.println(String.format("path %s does not start with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
             return wrapped.newInputFile(path, length);
         }
+        System.out.println(String.format("path %s starts with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
         return HadoopInputFile.fromPath(new LakeFSPath(path), length, wrapped.conf());
     }
 
@@ -60,9 +64,11 @@ public class LakeFSFileIO implements FileIO {
             path = String.format("s3a://%s/%s/%s", lakeFSRepo, lakeFSRef, path);
         }
         if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {
+            System.out.println(String.format("path %s does not start with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
             // not a path in the repository, treat as a regular path
             return wrapped.newOutputFile(path);
         }
+        System.out.println(String.format("path %s starts with s3a://%s/%s/", path, lakeFSRepo, lakeFSRef));
         return HadoopOutputFile.fromPath(new LakeFSPath(path), wrapped.conf());
     }
 

--- a/src/main/java/io/lakefs/iceberg/LakeFSFileIO.java
+++ b/src/main/java/io/lakefs/iceberg/LakeFSFileIO.java
@@ -32,7 +32,7 @@ public class LakeFSFileIO implements FileIO {
 
     @Override
     public InputFile newInputFile(String path) {
-        if (!path.startsWith("s3a://")) {
+        if (!path.matches("^[0-9a-z]*://.*")) {
             path = String.format("s3a://%s/%s/%s", lakeFSRepo, lakeFSRef, path);
         }
         if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {
@@ -44,7 +44,7 @@ public class LakeFSFileIO implements FileIO {
 
     @Override
     public InputFile newInputFile(String path, long length) {
-        if (!path.startsWith("s3a://")) {
+        if (!path.matches("^[0-9a-z]*://.*")) {
             path = String.format("s3a://%s/%s/%s", lakeFSRepo, lakeFSRef, path);
         }
         if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {
@@ -56,7 +56,7 @@ public class LakeFSFileIO implements FileIO {
 
     @Override
     public OutputFile newOutputFile(String path) {
-        if (!path.startsWith("s3a://")) {
+        if (!path.matches("^[0-9a-z]*://.*")) {
             path = String.format("s3a://%s/%s/%s", lakeFSRepo, lakeFSRef, path);
         }
         if (!path.startsWith(String.format("s3a://%s/%s/", lakeFSRepo, lakeFSRef))) {

--- a/src/test/java/io/lakefs/iceberg/TestLakeFSFileIO.java
+++ b/src/test/java/io/lakefs/iceberg/TestLakeFSFileIO.java
@@ -1,0 +1,35 @@
+package io.lakefs.iceberg;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.InputFile;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestLakeFSFileIO {
+
+    private LakeFSFileIO lakeFSFileIO;
+
+    @Before
+    public void setUp() {
+    HadoopFileIO hadoopFileIO = new HadoopFileIO(new Configuration());
+        String lakeFSRepo = "myLakeFSRepo";
+        String lakeFSRef = "myLakeFSRef";
+        lakeFSFileIO = new LakeFSFileIO(hadoopFileIO, lakeFSRepo, lakeFSRef);
+    }
+
+    @Test
+    public void testNewInputFile() {
+        // Test the behavior of newInputFile method
+        String relativePath = "path/in/repo";
+        String absolutePath = "s3a://myLakeFSRepo/myLakeFSRef/other/path/in/repo";
+        String externalPath = "s3a://otherBucket/otherPath";
+        InputFile relativeInputFile = lakeFSFileIO.newInputFile(relativePath);
+        Assert.assertEquals("path/in/repo", relativeInputFile.location());
+        InputFile absoluteInputFile = lakeFSFileIO.newInputFile(absolutePath);
+        Assert.assertEquals("other/path/in/repo", absoluteInputFile.location());
+        InputFile externalInputFile = lakeFSFileIO.newInputFile(externalPath);
+        Assert.assertEquals("s3a://otherBucket/otherPath", externalInputFile.location());
+    }
+}


### PR DESCRIPTION
Resolves #39.

Allow lakeFS Iceberg catalog to work with external (non-lakeFS) paths.
This way, an imported table which includes such paths, can still work.

## Assumptions
1. Used `lakectl import` to import a Iceberg table.
2. The original Iceberg table is in Hadoop Iceberg Catalog format.
3. When querying the table, the client has access to the original storage.
4. (If original table is in S3) Per-bucket configuration is used to point S3A to the lakeFS S3 gateway, but only for the specific repository name. For other bucket names, it uses AWS S3.